### PR TITLE
Removed logic for setting the PWM pin as OUT inside the constructor.

### DIFF
--- a/lib/python/TI/GPIO/gpio.py
+++ b/lib/python/TI/GPIO/gpio.py
@@ -692,7 +692,6 @@ class SW_PWM(object):
         self._stop_thread        = False
         self._calculate_times()
         _channel_configuration[channel] = OUT
-        GPIO.setup(channel, GPIO.OUT)
         _sw_pwm_channels[channel] = True
         self._init = True
 


### PR DESCRIPTION
The PWM pin needs to be set as OUT by the caller before instantiating
the PWM object.