### PR TITLE
[PY] RPi Header Support for AM62A-SK

### DIFF
--- a/lib/python/TI/GPIO/gpio_pin_data.py
+++ b/lib/python/TI/GPIO/gpio_pin_data.py
@@ -25,6 +25,7 @@ import sys
 J721E_SK = "J721E_SK"
 AM68_SK = "AM68_SK"
 AM69_SK = "AM69_SK"
+AM62A_SK = "AM62A_SK"
 
 OFFSET_ENTRY = 0
 GPIO_NAME_ENTRY = 1  # Currently unused
@@ -156,6 +157,41 @@ compats_am69sk = (
     "ti,j784s4",
 )
 
+AM62A_SK_PIN_DEFS = [
+    #   OFFSET     sysfs_dir      BOARD BCM SOC_NAME    PWM_SysFs  PWM_Id
+    (44, {}, "600000.gpio", 3, 2, "GPIO0_44", None, None),
+    (43, {}, "600000.gpio", 5, 3, "GPIO0_43", None, None),
+    (30, {}, "601000.gpio", 7, 4, "GPIO1_30", None, None),
+    (25, {}, "601000.gpio", 8, 14, "GPIO1_25", None, None),
+    (24, {}, "601000.gpio", 10, 15, "GPIO1_24", None, None),
+    (11, {}, "601000.gpio", 11, 17, "GPIO1_11", None, None),
+    (14, {}, "601000.gpio", 12, 18, "GPIO1_14", "23000000.pwm", 1),
+    (42, {}, "600000.gpio", 13, 27, "GPIO0_42", None, None),
+    (22, {}, "601000.gpio", 15, 22, "GPIO1_22", None, None),
+    (38, {}, "600000.gpio", 16, 23, "GPIO0_38", None, None),
+    (39, {}, "600000.gpio", 18, 24, "GPIO0_39", None, None),
+    (18, {}, "601000.gpio", 19, 10, "GPIO1_18", None, None),
+    (19, {}, "601000.gpio", 21, 9, "GPIO1_19", None, None),
+    (14, {}, "600000.gpio", 22, 25, "GPIO0_14", None, None),
+    (17, {}, "601000.gpio", 23, 11, "GPIO1_17", None, None),
+    (15, {}, "601000.gpio", 24, 8, "GPIO1_15", None, None),
+    (16, {}, "601000.gpio", 26, 7, "GPIO1_16", None, None),
+    (36, {}, "600000.gpio", 29, 5, "GPIO0_36", None, None),
+    (33, {}, "600000.gpio", 31, 6, "GPIO0_33", None, None),
+    (40, {}, "600000.gpio", 32, 12, "GPIO0_40", None, None),
+    (10, {}, "601000.gpio", 33, 13, "GPIO1_10", "23010000.pwm", 1),
+    (13, {}, "601000.gpio", 35, 19, "GPIO1_13", "23000000.pwm", 0),
+    (9, {}, "601000.gpio", 36, 16, "GPIO1_09", "23010000.pwm", 0),
+    (41, {}, "600000.gpio", 37, 26, "GPIO0_41", None, None),
+    (8, {}, "601000.gpio", 38, 20, "GPIO1_08", None, None),
+    (7, {}, "601000.gpio", 40, 21, "GPIO1_07", None, None),
+]
+
+compats_am62ask = (
+    "ti,am62a7-sk",
+    "ti,am62a7",
+)
+
 board_gpio_data = {
     J721E_SK: (
         J721E_SK_PIN_DEFS,
@@ -185,6 +221,16 @@ board_gpio_data = {
             "TYPE": "AM69-SK",
             "MANUFACTURER": "TI",
             "PROCESSOR": "ARM A72",
+        },
+    ),
+    AM62A_SK: (
+        AM62A_SK_PIN_DEFS,
+        {
+            "RAM": "4096M",
+            "REVISION": "E2",
+            "TYPE": "AM62A-SK",
+            "MANUFACTURER": "TI",
+            "PROCESSOR": "ARM A53",
         },
     ),
 }
@@ -252,6 +298,9 @@ WARNING: and in fact is unlikely to work correctly.
         model = AM68_SK
     elif matches(compats_am69sk):
         model = AM69_SK
+    elif matches(compats_am62ask):
+        model = AM62A_SK
+
     else:
         raise Exception("Could not determine TI SOC model")
 
@@ -266,6 +315,7 @@ WARNING: and in fact is unlikely to work correctly.
         "/sys/devices/platform/",
         "/sys/devices/platform/bus@100000/",
         "/sys/devices/platform/bus@100000/bus@100000:bus@28380000/",
+        "/sys/devices/platform/bus@f0000/",
     ]
 
     # Get the gpiochip offsets

--- a/samples/simple_pwm.py
+++ b/samples/simple_pwm.py
@@ -27,6 +27,7 @@ output_pins = {
     "J721E_SK": 32,
     "AM68_SK": 32,
     "AM69_SK": 32,
+    "AM62A_SK": 35,
 }
 output_pin = output_pins.get(GPIO.model, None)
 if output_pin is None:

--- a/samples/test_all_pins.py
+++ b/samples/test_all_pins.py
@@ -42,6 +42,11 @@ pin_datas = {
         "input_only": (),
         "hw_pwm": (32, 33, 36),  # HW PWMs to skip for this test
     },
+    "AM62A_SK": {
+        "unimplemented": (),
+        "input_only": (),
+        "hw_pwm": (12, 33, 35, 36),  # HW PWMs to skip for this test
+    },
 }
 
 pin_data = pin_datas.get(GPIO.model)

--- a/samples/test_all_pins_input.py
+++ b/samples/test_all_pins_input.py
@@ -78,10 +78,37 @@ am69_sk_pin_defs = [
     (40, 21, "GPIO0_45"),
 ]
 
+am62a_sk_pin_defs = [
+    # BOARD BCM SOC
+    (3, 2, "GPIO0_44"),
+    (5, 3, "GPIO0_43"),
+    (7, 4, "GPIO1_30"),
+    (8, 14, "GPIO1_25"),
+    (10, 15, "GPIO1_24"),
+    (11, 17, "GPIO1_11"),
+    (13, 27, "GPIO0_42"),
+    (15, 22, "GPIO1_22"),
+    (16, 23, "GPIO0_38"),
+    (18, 24, "GPIO0_39"),
+    (19, 10, "GPIO1_18"),
+    (21, 9, "GPIO1_19"),
+    (22, 25, "GPIO0_14"),
+    (23, 11, "GPIO1_17"),
+    (24, 8, "GPIO1_15"),
+    (26, 7, "GPIO1_16"),
+    (29, 5, "GPIO0_36"),
+    (31, 6, "GPIO0_33"),
+    (32, 12, "GPIO0_40"),
+    (37, 26, "GPIO0_41"),
+    (38, 20, "GPIO1_08"),
+    (40, 21, "GPIO1_07"),
+]
+
 all_pins = {
     "J721E_SK": j721e_sk_pin_defs,  # all non hw-pwm pins
     "AM68_SK": am68_sk_pin_defs,  # all non hw-pwm pins
     "AM69_SK": am69_sk_pin_defs,  # all non hw-pwm pins
+    "AM62A_SK": am62a_sk_pin_defs,  # all non hw-pwm pins
 }
 
 pin_defs = all_pins.get(GPIO.model)

--- a/samples/test_all_pins_pwm.py
+++ b/samples/test_all_pins_pwm.py
@@ -36,6 +36,10 @@ all_pwm_pins = {
         "sw_pwm": [7, 15, 19, 21, 22, 23, 24, 26, 29, 31],  # Can be any valid GPIO pins
         "hw_pwm": [32, 33, 36],  # Designated HW PWM pins
     },
+    "AM62A_SK": {
+        "sw_pwm": [13, 15, 16, 18, 22, 31, 32, 37],  # Can be any valid GPIO pins
+        "hw_pwm": [12, 33, 35, 36],  # Designated HW PWM pins
+    },
 }
 
 pin_data = all_pwm_pins.get(GPIO.model)


### PR DESCRIPTION
added pin mapping for AM62A in lib/TI/GPIO/gpio_pin_data.py modified sample tests to support AM62A